### PR TITLE
Fixed building store package from Visual Studio

### DIFF
--- a/HackChecklist.sln
+++ b/HackChecklist.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UWP", "UWP\UWP.csproj", "{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -12,48 +12,28 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackgroundFormProcess", "Ba
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|ARM.ActiveCfg = Debug|ARM
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|ARM.Build.0 = Debug|ARM
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|ARM.Deploy.0 = Debug|ARM
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x64.ActiveCfg = Debug|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x64.Build.0 = Debug|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x64.Deploy.0 = Debug|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x86.ActiveCfg = Debug|x86
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x86.Build.0 = Debug|x86
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Debug|x86.Deploy.0 = Debug|x86
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|Any CPU.ActiveCfg = Release|x86
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|ARM.ActiveCfg = Release|ARM
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|ARM.Build.0 = Release|ARM
-		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|ARM.Deploy.0 = Release|ARM
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x64.ActiveCfg = Release|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x64.Build.0 = Release|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x64.Deploy.0 = Release|x64
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x86.ActiveCfg = Release|x86
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x86.Build.0 = Release|x86
 		{68E3E0F8-DF4C-4A7C-A8D2-F1000E2219D1}.Release|x86.Deploy.0 = Release|x86
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|ARM.Build.0 = Debug|Any CPU
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|x64.ActiveCfg = Debug|x64
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|x64.Build.0 = Debug|x64
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|x86.ActiveCfg = Debug|x86
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Debug|x86.Build.0 = Debug|x86
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|ARM.ActiveCfg = Release|Any CPU
-		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|ARM.Build.0 = Release|Any CPU
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|x64.ActiveCfg = Release|x64
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|x64.Build.0 = Release|x64
 		{EDAFC744-963E-4EC6-9D03-959F7C1DC92A}.Release|x86.ActiveCfg = Release|x86

--- a/UWP/Package.appxmanifest
+++ b/UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" IgnorableNamespaces="uap mp rescap desktop">
-  <Identity Name="Microsoft.AppServiceBridge" Publisher="CN=stamm" Version="1.0.8.0" />
+  <Identity Name="Microsoft.AppServiceBridge" Publisher="CN=stamm" Version="1.0.9.0" />
   <mp:PhoneIdentity PhoneProductId="1aa93327-07b6-485f-bc70-70cbd5a9ca0a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Hack Checklist</DisplayName>
@@ -24,7 +24,7 @@
         <uap:Extension Category="windows.appService">
           <uap:AppService Name="CommunicationService" />
         </uap:Extension>
-        <desktop:Extension Category="windows.fullTrustProcess" Executable="BackgroundFormProcess.exe" />
+        <desktop:Extension Category="windows.fullTrustProcess" Executable="BackgroundFormProcess\BackgroundFormProcess.exe" />
       </Extensions>
     </Application>
   </Applications>

--- a/UWP/UWP.csproj
+++ b/UWP/UWP.csproj
@@ -152,6 +152,18 @@
       <DeploymentContent>true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"
+      Include="..\BackgroundFormProcess\bin\x64\Debug\BackgroundFormProcess.exe">
+      <Link>BackgroundFormProcess/BackgroundFormProcess.exe</Link>
+      <DeploymentContent>true</DeploymentContent>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Condition="'$(Configuration)|$(Platform)' == 'Release|x64'"
+      Include="..\BackgroundFormProcess\bin\x64\Release\BackgroundFormProcess.exe">
+      <Link>BackgroundFormProcess/BackgroundFormProcess.exe</Link>
+      <DeploymentContent>true</DeploymentContent>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UWP/UWP.csproj
+++ b/UWP/UWP.csproj
@@ -139,9 +139,20 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /y /s "$(SolutionDir)BackgroundFormProcess\bin\$(Platform)\$(ConfigurationName)\BackgroundFormProcess.exe" "$(SolutionDir)\UWP\bin\$(Platform)\$(ConfigurationName)\AppX"</PostBuildEvent>
-  </PropertyGroup>
+  <ItemGroup Label="BackgroundProcess">
+    <Content Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" 
+      Include="..\BackgroundFormProcess\bin\x86\Debug\BackgroundFormProcess.exe">
+      <Link>BackgroundFormProcess/BackgroundFormProcess.exe</Link>
+      <DeploymentContent>true</DeploymentContent>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Condition="'$(Configuration)|$(Platform)' == 'Release|x86'"
+      Include="..\BackgroundFormProcess\bin\x86\Release\BackgroundFormProcess.exe">
+      <Link>BackgroundFormProcess/BackgroundFormProcess.exe</Link>
+      <DeploymentContent>true</DeploymentContent>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This PR simplifies the building and packaging of the Hack Checklist app. It adds the following:

1. Building and running the app now works with F5. No need to deploy first, 
2. Creating the store package now works from Visual Studio. No need to use the command line script.
3. Removed AnyCPU and ARM platforms as they won't work with Centennial
4. Added support for x64 builds.